### PR TITLE
Implement basic scale property for handling parent container scale

### DIFF
--- a/src/Selecto.tsx
+++ b/src/Selecto.tsx
@@ -70,6 +70,7 @@ class Selecto extends Component {
             checkInput: false,
             preventDefault: false,
             cspNonce: "",
+            scale: 1,
             ratio: 0,
             ...options,
         };
@@ -581,11 +582,12 @@ class Selecto extends Component {
             width,
             height,
         } = rect;
+        const scale = this.options.scale
         this.target.style.cssText
             += `display: block;`
             + `left:0px;top:0px;`
-            + `transform: translate(${left}px, ${top}px);`
-            + `width:${width}px;height:${height}px;`;
+            + `transform: translate(${left * scale}px, ${top * scale}px);`
+            + `width:${width * scale}px;height:${height * scale}px;`;
 
         const passedTargets = this.hitTest(
             rect, datas.startX, datas.startY, datas.selectableTargets, datas.selectableRects);

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -28,6 +28,7 @@ export const PROPERTIES = [
     "checkInput",
     "preventDefault",
     "ratio",
+    "scale"
 ] as const;
 /**
  * @memberof Selecto
@@ -55,6 +56,7 @@ export const OPTION_TYPES: { [key in keyof SelectoOptions]: any } = {
     preventDefault: Boolean,
     cspNonce: String,
     ratio: Number,
+    scale: Number,
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export interface SelectoOptions {
     preventDefault: boolean;
     cspNonce: string;
     ratio: number;
+    scale: number;
 }
 
 export interface Hypertext {


### PR DESCRIPTION
Hello, I've been using a couple of your excellent packages. 

I've run into a minor issue where a parent container with a transform: scale stops the Selecto visual indicator for the selection area showing correctly. The actual selection is correct, but the blue selection box is not. 

This PR probably isn't the best solution (the scale might be able to be automatically calculated), but it is what I'm using at the moment.